### PR TITLE
Redo wasm bindings

### DIFF
--- a/lightning-c-bindings/src/c_types/mod.rs
+++ b/lightning-c-bindings/src/c_types/mod.rs
@@ -387,13 +387,15 @@ impl Str {
 		if self.len == 0 { return ""; }
 		std::str::from_utf8(unsafe { std::slice::from_raw_parts(self.chars, self.len) }).unwrap()
 	}
-	pub(crate) fn into_string(self) -> String {
+	pub(crate) fn into_string(mut self) -> String {
 		let bytes = if self.len == 0 {
 			Vec::new()
 		} else if self.chars_is_owned {
-			unsafe {
+			let ret = unsafe {
 				Box::from_raw(std::slice::from_raw_parts_mut(unsafe { self.chars as *mut u8 }, self.len))
-			}.into()
+			}.into();
+			self.chars_is_owned = false;
+			ret
 		} else {
 			let mut ret = Vec::with_capacity(self.len);
 			ret.extend_from_slice(unsafe { std::slice::from_raw_parts(self.chars, self.len) });


### PR DESCRIPTION
I'm not sure why it succeeds locally but not on CI, but building WASM passes if we `-fembed-bitcode` (otherwise it thinks Rust/C have a different target tuple and errors out.