### PR TITLE
Correct clone logic for `Str`.

### DIFF
--- a/lightning-c-bindings/Cargo.toml
+++ b/lightning-c-bindings/Cargo.toml
@@ -18,10 +18,10 @@ crate-type = ["staticlib"
 bitcoin = "0.27"
 secp256k1 = { version = "0.20.3", features = ["global-context-less-secure"] }
 # Note that the following line is matched by genbindings to update the path
-lightning = { git = "https://github.com/rust-bitcoin/rust-lightning", rev = "367a2ccf2c1856bba67f12c82a4ab80d7941616f", features = ["allow_wallclock_use"] }
-lightning-persister = { git = "https://github.com/rust-bitcoin/rust-lightning", rev = "367a2ccf2c1856bba67f12c82a4ab80d7941616f" }
-lightning-invoice = { git = "https://github.com/rust-bitcoin/rust-lightning", rev = "367a2ccf2c1856bba67f12c82a4ab80d7941616f" }
-lightning-background-processor = { git = "https://github.com/rust-bitcoin/rust-lightning", rev = "367a2ccf2c1856bba67f12c82a4ab80d7941616f" }
+lightning = { git = "https://github.com/rust-bitcoin/rust-lightning", rev = "ad819ea70572b4775691e3fc386a788ff9438975", features = ["allow_wallclock_use"] }
+lightning-persister = { git = "https://github.com/rust-bitcoin/rust-lightning", rev = "ad819ea70572b4775691e3fc386a788ff9438975" }
+lightning-invoice = { git = "https://github.com/rust-bitcoin/rust-lightning", rev = "ad819ea70572b4775691e3fc386a788ff9438975" }
+lightning-background-processor = { git = "https://github.com/rust-bitcoin/rust-lightning", rev = "ad819ea70572b4775691e3fc386a788ff9438975" }
 
 # Always force panic=abort, further options are set in the genbindings.sh build script
 [profile.dev]

--- a/lightning-c-bindings/include/lightning.h
+++ b/lightning-c-bindings/include/lightning.h
@@ -11995,6 +11995,12 @@ struct LDKCResult_NetworkGraphDecodeErrorZ CResult_NetworkGraphDecodeErrorZ_err(
 void CResult_NetworkGraphDecodeErrorZ_free(struct LDKCResult_NetworkGraphDecodeErrorZ _res);
 
 /**
+ * Creates a new CResult_NetworkGraphDecodeErrorZ which has the same data as `orig`
+ * but with all dynamically-allocated buffers duplicated in new buffers.
+ */
+struct LDKCResult_NetworkGraphDecodeErrorZ CResult_NetworkGraphDecodeErrorZ_clone(const struct LDKCResult_NetworkGraphDecodeErrorZ *NONNULL_PTR orig);
+
+/**
  * Creates a new CResult_NetAddressu8Z in the success state.
  */
 struct LDKCResult_NetAddressu8Z CResult_NetAddressu8Z_ok(struct LDKNetAddress o);
@@ -19435,16 +19441,6 @@ struct LDKCVec_u8Z ShutdownScript_write(const struct LDKShutdownScript *NONNULL_
 struct LDKCResult_ShutdownScriptDecodeErrorZ ShutdownScript_read(struct LDKu8slice ser);
 
 /**
- * Generates a P2PKH script pubkey from the given [`PubkeyHash`].
- */
-MUST_USE_RES struct LDKShutdownScript ShutdownScript_new_p2pkh(const uint8_t (*pubkey_hash)[20]);
-
-/**
- * Generates a P2SH script pubkey from the given [`ScriptHash`].
- */
-MUST_USE_RES struct LDKShutdownScript ShutdownScript_new_p2sh(const uint8_t (*script_hash)[20]);
-
-/**
  * Generates a P2WPKH script pubkey from the given [`WPubkeyHash`].
  */
 MUST_USE_RES struct LDKShutdownScript ShutdownScript_new_p2wpkh(const uint8_t (*pubkey_hash)[20]);
@@ -19820,6 +19816,11 @@ struct LDKCResult_RouteLightningErrorZ get_route(struct LDKPublicKey our_node_id
  * Frees any resources used by the NetworkGraph, if is_owned is set and inner is non-NULL.
  */
 void NetworkGraph_free(struct LDKNetworkGraph this_obj);
+
+/**
+ * Creates a copy of the NetworkGraph
+ */
+struct LDKNetworkGraph NetworkGraph_clone(const struct LDKNetworkGraph *NONNULL_PTR orig);
 
 /**
  * Frees any resources used by the ReadOnlyNetworkGraph, if is_owned is set and inner is non-NULL.

--- a/lightning-c-bindings/src/c_types/derived.rs
+++ b/lightning-c-bindings/src/c_types/derived.rs
@@ -8397,6 +8397,23 @@ impl From<crate::c_types::CResultTempl<crate::lightning::routing::network_graph:
 		}
 	}
 }
+impl Clone for CResult_NetworkGraphDecodeErrorZ {
+	fn clone(&self) -> Self {
+		if self.result_ok {
+			Self { result_ok: true, contents: CResult_NetworkGraphDecodeErrorZPtr {
+				result: Box::into_raw(Box::new(<crate::lightning::routing::network_graph::NetworkGraph>::clone(unsafe { &*self.contents.result })))
+			} }
+		} else {
+			Self { result_ok: false, contents: CResult_NetworkGraphDecodeErrorZPtr {
+				err: Box::into_raw(Box::new(<crate::lightning::ln::msgs::DecodeError>::clone(unsafe { &*self.contents.err })))
+			} }
+		}
+	}
+}
+#[no_mangle]
+/// Creates a new CResult_NetworkGraphDecodeErrorZ which has the same data as `orig`
+/// but with all dynamically-allocated buffers duplicated in new buffers.
+pub extern "C" fn CResult_NetworkGraphDecodeErrorZ_clone(orig: &CResult_NetworkGraphDecodeErrorZ) -> CResult_NetworkGraphDecodeErrorZ { Clone::clone(&orig) }
 #[repr(C)]
 /// The contents of CResult_NetAddressu8Z
 pub union CResult_NetAddressu8ZPtr {

--- a/lightning-c-bindings/src/c_types/mod.rs
+++ b/lightning-c-bindings/src/c_types/mod.rs
@@ -435,7 +435,6 @@ pub(crate) fn deserialize_obj_arg<A, I: lightning::util::ser::ReadableArgs<A>>(s
 }
 
 #[repr(C)]
-#[derive(Clone)]
 /// A Rust str object, ie a reference to a UTF8-valid string.
 /// This is *not* null-terminated so cannot be used directly as a C string!
 pub struct Str {
@@ -477,6 +476,11 @@ impl Into<Str> for String {
 	fn into(self) -> Str {
 		let s = Box::leak(self.into_boxed_str());
 		Str { chars: s.as_ptr(), len: s.len(), chars_is_owned: true }
+	}
+}
+impl Clone for Str {
+	fn clone(&self) -> Self {
+		self.into_str().clone().into()
 	}
 }
 

--- a/lightning-c-bindings/src/lightning/ln/script.rs
+++ b/lightning-c-bindings/src/lightning/ln/script.rs
@@ -176,22 +176,6 @@ pub extern "C" fn ShutdownScript_read(ser: crate::c_types::u8slice) -> crate::c_
 	let mut local_res = match res { Ok(mut o) => crate::c_types::CResultTempl::ok( { crate::lightning::ln::script::ShutdownScript { inner: ObjOps::heap_alloc(o), is_owned: true } }).into(), Err(mut e) => crate::c_types::CResultTempl::err( { crate::lightning::ln::msgs::DecodeError { inner: ObjOps::heap_alloc(e), is_owned: true } }).into() };
 	local_res
 }
-/// Generates a P2PKH script pubkey from the given [`PubkeyHash`].
-#[must_use]
-#[no_mangle]
-pub extern "C" fn ShutdownScript_new_p2pkh(pubkey_hash: *const [u8; 20]) -> ShutdownScript {
-	let mut ret = lightning::ln::script::ShutdownScript::new_p2pkh(&bitcoin::hash_types::PubkeyHash::from_hash(bitcoin::hashes::Hash::from_inner(unsafe { *pubkey_hash }.clone())));
-	ShutdownScript { inner: ObjOps::heap_alloc(ret), is_owned: true }
-}
-
-/// Generates a P2SH script pubkey from the given [`ScriptHash`].
-#[must_use]
-#[no_mangle]
-pub extern "C" fn ShutdownScript_new_p2sh(script_hash: *const [u8; 20]) -> ShutdownScript {
-	let mut ret = lightning::ln::script::ShutdownScript::new_p2sh(&bitcoin::hash_types::ScriptHash::from_hash(bitcoin::hashes::Hash::from_inner(unsafe { *script_hash }.clone())));
-	ShutdownScript { inner: ObjOps::heap_alloc(ret), is_owned: true }
-}
-
 /// Generates a P2WPKH script pubkey from the given [`WPubkeyHash`].
 #[must_use]
 #[no_mangle]

--- a/lightning-c-bindings/src/lightning/routing/network_graph.rs
+++ b/lightning-c-bindings/src/lightning/routing/network_graph.rs
@@ -65,6 +65,25 @@ impl NetworkGraph {
 		ret
 	}
 }
+impl Clone for NetworkGraph {
+	fn clone(&self) -> Self {
+		Self {
+			inner: if <*mut nativeNetworkGraph>::is_null(self.inner) { std::ptr::null_mut() } else {
+				ObjOps::heap_alloc(unsafe { &*ObjOps::untweak_ptr(self.inner) }.clone()) },
+			is_owned: true,
+		}
+	}
+}
+#[allow(unused)]
+/// Used only if an object of this type is returned as a trait impl by a method
+pub(crate) extern "C" fn NetworkGraph_clone_void(this_ptr: *const c_void) -> *mut c_void {
+	Box::into_raw(Box::new(unsafe { (*(this_ptr as *mut nativeNetworkGraph)).clone() })) as *mut c_void
+}
+#[no_mangle]
+/// Creates a copy of the NetworkGraph
+pub extern "C" fn NetworkGraph_clone(orig: &NetworkGraph) -> NetworkGraph {
+	orig.clone()
+}
 
 use lightning::routing::network_graph::ReadOnlyNetworkGraph as nativeReadOnlyNetworkGraphImport;
 type nativeReadOnlyNetworkGraph = nativeReadOnlyNetworkGraphImport<'static>;


### PR DESCRIPTION
Previously we'd blindly clone'd the fields, which, if
`data_is_owned` is set, will always result in a a double-free.

Instead, we always clone the underlying bytes, setting
`data_is_owned` on the returned value since its likely the caller
wants to hold onto the string outside of the current context.