### PR TITLE
Redo tuple-reference mapping and prep for 106

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
           touch src/version.rs
           RUSTFLAGS="--cfg=c_bindings" cargo check --features std
       - name: Install cbindgen
-        run: cargo install --force cbindgen
+        run: cargo install --version 0.20.0 cbindgen
       - name: Checkout Rust-Lightning git
         run: |
           git clone https://github.com/rust-bitcoin/rust-lightning
@@ -78,7 +78,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install cbindgen
-        run: cargo install --force cbindgen
+        run: cargo install --version 0.20.0 cbindgen
       - name: Checkout Rust-Lightning git
         run: |
           git clone https://github.com/rust-bitcoin/rust-lightning

--- a/c-bindings-gen/src/blocks.rs
+++ b/c-bindings-gen/src/blocks.rs
@@ -272,22 +272,14 @@ pub fn write_tuple_block<W: std::io::Write>(w: &mut W, mangled_container: &str, 
 	writeln!(w, "pub struct {} {{", mangled_container).unwrap();
 	for (idx, ty) in types.iter().enumerate() {
 		writeln!(w, "\t/// The element at position {}", idx).unwrap();
-		if ty.starts_with("&'static ") {
-			writeln!(w, "\tpub {}: {},", ('a' as u8 + idx as u8) as char, &ty[9..]).unwrap();
-		} else {
-			writeln!(w, "\tpub {}: {},", ('a' as u8 + idx as u8) as char, ty).unwrap();
-		}
+		writeln!(w, "\tpub {}: {},", ('a' as u8 + idx as u8) as char, ty).unwrap();
 	}
 	writeln!(w, "}}").unwrap();
 
 	let mut tuple_str = "(".to_owned();
 	for (idx, ty) in types.iter().enumerate() {
 		if idx != 0 { tuple_str += ", "; }
-		if ty.starts_with("&'static ") {
-			tuple_str += &ty[9..];
-		} else {
-			tuple_str += ty;
-		}
+		tuple_str += ty;
 	}
 	tuple_str += ")";
 
@@ -314,14 +306,8 @@ pub fn write_tuple_block<W: std::io::Write>(w: &mut W, mangled_container: &str, 
 		writeln!(w, "impl Clone for {} {{", mangled_container).unwrap();
 		writeln!(w, "\tfn clone(&self) -> Self {{").unwrap();
 		writeln!(w, "\t\tSelf {{").unwrap();
-		for (idx, ty) in types.iter().enumerate() {
-			if ty.starts_with("&'static ") {
-				// Assume blindly the type is opaque. If its not we'll fail to build.
-				// Really we should never have derived structs with a reference type.
-				write!(w, "\t\t\t{}: {} {{ inner: self.{}.inner, is_owned: false}},", ('a' as u8 + idx as u8) as char, &ty[9..], ('a' as u8 + idx as u8) as char).unwrap();
-			} else{
-				writeln!(w, "\t\t\t{}: Clone::clone(&self.{}),", ('a' as u8 + idx as u8) as char, ('a' as u8 + idx as u8) as char).unwrap();
-			}
+		for idx in 0..types.len() {
+			writeln!(w, "\t\t\t{}: Clone::clone(&self.{}),", ('a' as u8 + idx as u8) as char, ('a' as u8 + idx as u8) as char).unwrap();
 		}
 		writeln!(w, "\t\t}}").unwrap();
 		writeln!(w, "\t}}").unwrap();
@@ -341,14 +327,8 @@ pub fn write_tuple_block<W: std::io::Write>(w: &mut W, mangled_container: &str, 
 	}
 	writeln!(w, ") -> {} {{", mangled_container).unwrap();
 	write!(w, "\t{} {{ ", mangled_container).unwrap();
-	for (idx, ty) in types.iter().enumerate() {
-		if ty.starts_with("&'static ") {
-			// Assume blindly the type is opaque. If its not we'll fail to build.
-			// Really we should never have derived structs with a reference type.
-			write!(w, "{}: {} {{ inner: {}.inner, is_owned: false}}, ", ('a' as u8 + idx as u8) as char, &ty[9..], ('a' as u8 + idx as u8) as char).unwrap();
-		} else {
-			write!(w, "{}, ", ('a' as u8 + idx as u8) as char).unwrap();
-		}
+	for idx in 0..types.len() {
+		write!(w, "{}, ", ('a' as u8 + idx as u8) as char).unwrap();
 	}
 	writeln!(w, "}}\n}}\n").unwrap();
 

--- a/c-bindings-gen/src/types.rs
+++ b/c-bindings-gen/src/types.rs
@@ -2714,7 +2714,8 @@ impl<'a, 'c: 'a> TypeResolver<'a, 'c> {
 				if !c_ty {
 					self.write_rust_path(w, generics, path);
 				} else {
-					write!(w, "{}", full_path).unwrap();
+					// We shouldn't be mapping references in types, so panic here
+					unimplemented!();
 				}
 			} else if is_ref {
 				write!(w, "&{}{}{}", if is_mut { "mut " } else { "" }, crate_pfx, full_path).unwrap();

--- a/c-bindings-gen/src/types.rs
+++ b/c-bindings-gen/src/types.rs
@@ -772,7 +772,6 @@ impl<'a> CrateTypes<'a> {
 		self.clonable_types.borrow_mut().insert(object);
 	}
 	pub fn is_clonable(&self, object: &str) -> bool {
-		object.starts_with("&'static ") ||
 		self.clonable_types.borrow().contains(object)
 	}
 	pub fn write_new_template(&self, mangled_container: String, has_destructor: bool, created_container: &[u8]) {

--- a/genbindings.sh
+++ b/genbindings.sh
@@ -305,7 +305,7 @@ fi
 gcc $LOCAL_CFLAGS -fPIC -std=c99 -Wall -g -pthread -I../ldk-net ../ldk-net/ldk_net.c -c -o ldk_net.o
 if [ "$2" = "true" ]; then
 	g++ $LOCAL_CFLAGS -std=c++11 -Wall -g -pthread -DREAL_NET -I../ldk-net ldk_net.o demo.cpp target/debug/libldk.a -ldl -lm
-	if [ -x "`which valgrind`" ]; then
+	if [ -x "`which valgrind`" -a "$(uname -m)" != "ppc64le" ]; then
 		valgrind --error-exitcode=4 --memcheck:leak-check=full --show-leak-kinds=all ./a.out
 		echo
 	else

--- a/lightning-c-bindings/include/lightning.h
+++ b/lightning-c-bindings/include/lightning.h
@@ -4308,20 +4308,6 @@ typedef struct MUST_USE_STRUCT LDKNetworkGraph {
    bool is_owned;
 } LDKNetworkGraph;
 
-/**
- * A tuple of 2 elements. See the individual fields for the types contained.
- */
-typedef struct LDKC2Tuple_ProbabilisticScoringParametersNetworkGraphZ {
-   /**
-    * The element at position 0
-    */
-   struct LDKProbabilisticScoringParameters a;
-   /**
-    * The element at position 1
-    */
-   struct LDKNetworkGraph b;
-} LDKC2Tuple_ProbabilisticScoringParametersNetworkGraphZ;
-
 
 
 /**
@@ -13406,22 +13392,6 @@ void CResult_ProbabilisticScoringParametersDecodeErrorZ_free(struct LDKCResult_P
  * but with all dynamically-allocated buffers duplicated in new buffers.
  */
 struct LDKCResult_ProbabilisticScoringParametersDecodeErrorZ CResult_ProbabilisticScoringParametersDecodeErrorZ_clone(const struct LDKCResult_ProbabilisticScoringParametersDecodeErrorZ *NONNULL_PTR orig);
-
-/**
- * Creates a new tuple which has the same data as `orig`
- * but with all dynamically-allocated buffers duplicated in new buffers.
- */
-struct LDKC2Tuple_ProbabilisticScoringParametersNetworkGraphZ C2Tuple_ProbabilisticScoringParametersNetworkGraphZ_clone(const struct LDKC2Tuple_ProbabilisticScoringParametersNetworkGraphZ *NONNULL_PTR orig);
-
-/**
- * Creates a new C2Tuple_ProbabilisticScoringParametersNetworkGraphZ from the contained elements.
- */
-struct LDKC2Tuple_ProbabilisticScoringParametersNetworkGraphZ C2Tuple_ProbabilisticScoringParametersNetworkGraphZ_new(struct LDKProbabilisticScoringParameters a, const struct LDKNetworkGraph *NONNULL_PTR b);
-
-/**
- * Frees any resources used by the C2Tuple_ProbabilisticScoringParametersNetworkGraphZ.
- */
-void C2Tuple_ProbabilisticScoringParametersNetworkGraphZ_free(struct LDKC2Tuple_ProbabilisticScoringParametersNetworkGraphZ _res);
 
 /**
  * Creates a new CResult_ProbabilisticScorerDecodeErrorZ in the success state.
@@ -25496,7 +25466,7 @@ struct LDKCVec_u8Z ProbabilisticScorer_write(const struct LDKProbabilisticScorer
 /**
  * Read a ProbabilisticScorer from a byte array, created by ProbabilisticScorer_write
  */
-struct LDKCResult_ProbabilisticScorerDecodeErrorZ ProbabilisticScorer_read(struct LDKu8slice ser, struct LDKC2Tuple_ProbabilisticScoringParametersNetworkGraphZ arg);
+struct LDKCResult_ProbabilisticScorerDecodeErrorZ ProbabilisticScorer_read(struct LDKu8slice ser, struct LDKProbabilisticScoringParameters arg_a, const struct LDKNetworkGraph *NONNULL_PTR arg_b);
 
 /**
  * Frees any resources used by the FilesystemPersister, if is_owned is set and inner is non-NULL.

--- a/lightning-c-bindings/include/lightningpp.hpp
+++ b/lightning-c-bindings/include/lightningpp.hpp
@@ -209,8 +209,8 @@ class CResult_ChannelReestablishDecodeErrorZ;
 class CResult_CommitmentSignedDecodeErrorZ;
 class CVec_UpdateAddHTLCZ;
 class CResult_UnsignedNodeAnnouncementDecodeErrorZ;
-class CResult_InitFeaturesDecodeErrorZ;
 class COption_u32Z;
+class CResult_InitFeaturesDecodeErrorZ;
 class CResult_StaticPaymentOutputDescriptorDecodeErrorZ;
 class CResult_PaymentIdPaymentSendFailureZ;
 class CResult_ReplyChannelRangeDecodeErrorZ;
@@ -318,24 +318,23 @@ class CResult_NonePeerHandleErrorZ;
 class CResult_COption_EventZDecodeErrorZ;
 class CResult_CVec_SignatureZNoneZ;
 class COption_CVec_NetAddressZZ;
-class C2Tuple_ProbabilisticScoringParametersNetworkGraphZ;
 class CResult__u832APIErrorZ;
 class CResult_PaymentIdPaymentErrorZ;
 class CResult_DescriptionCreationErrorZ;
-class CResult_PayeePubKeyErrorZ;
 class CResult_COption_MonitorEventZDecodeErrorZ;
+class CResult_PayeePubKeyErrorZ;
 class CVec_C2Tuple_PublicKeyTypeZZ;
 class CResult_RoutingFeesDecodeErrorZ;
+class CResult_QueryShortChannelIdsDecodeErrorZ;
 class CResult_InvoiceSemanticErrorZ;
 class CResult_UpdateAddHTLCDecodeErrorZ;
-class CResult_QueryShortChannelIdsDecodeErrorZ;
+class CVec_PhantomRouteHintsZ;
 class CResult_CounterpartyChannelTransactionParametersDecodeErrorZ;
 class CResult_NoneAPIErrorZ;
 class CVec_NetAddressZ;
 class CResult_ChannelDetailsDecodeErrorZ;
 class CVec_C2Tuple_usizeTransactionZZ;
 class CVec_PublicKeyZ;
-class CVec_PhantomRouteHintsZ;
 class COption_MonitorEventZ;
 class COption_TypeZ;
 class CResult_COption_TypeZDecodeErrorZ;
@@ -4206,21 +4205,6 @@ public:
 	const LDKCResult_UnsignedNodeAnnouncementDecodeErrorZ* operator &() const { return &self; }
 	const LDKCResult_UnsignedNodeAnnouncementDecodeErrorZ* operator ->() const { return &self; }
 };
-class CResult_InitFeaturesDecodeErrorZ {
-private:
-	LDKCResult_InitFeaturesDecodeErrorZ self;
-public:
-	CResult_InitFeaturesDecodeErrorZ(const CResult_InitFeaturesDecodeErrorZ&) = delete;
-	CResult_InitFeaturesDecodeErrorZ(CResult_InitFeaturesDecodeErrorZ&& o) : self(o.self) { memset(&o, 0, sizeof(CResult_InitFeaturesDecodeErrorZ)); }
-	CResult_InitFeaturesDecodeErrorZ(LDKCResult_InitFeaturesDecodeErrorZ&& m_self) : self(m_self) { memset(&m_self, 0, sizeof(LDKCResult_InitFeaturesDecodeErrorZ)); }
-	operator LDKCResult_InitFeaturesDecodeErrorZ() && { LDKCResult_InitFeaturesDecodeErrorZ res = self; memset(&self, 0, sizeof(LDKCResult_InitFeaturesDecodeErrorZ)); return res; }
-	~CResult_InitFeaturesDecodeErrorZ() { CResult_InitFeaturesDecodeErrorZ_free(self); }
-	CResult_InitFeaturesDecodeErrorZ& operator=(CResult_InitFeaturesDecodeErrorZ&& o) { CResult_InitFeaturesDecodeErrorZ_free(self); self = o.self; memset(&o, 0, sizeof(CResult_InitFeaturesDecodeErrorZ)); return *this; }
-	LDKCResult_InitFeaturesDecodeErrorZ* operator &() { return &self; }
-	LDKCResult_InitFeaturesDecodeErrorZ* operator ->() { return &self; }
-	const LDKCResult_InitFeaturesDecodeErrorZ* operator &() const { return &self; }
-	const LDKCResult_InitFeaturesDecodeErrorZ* operator ->() const { return &self; }
-};
 class COption_u32Z {
 private:
 	LDKCOption_u32Z self;
@@ -4235,6 +4219,21 @@ public:
 	LDKCOption_u32Z* operator ->() { return &self; }
 	const LDKCOption_u32Z* operator &() const { return &self; }
 	const LDKCOption_u32Z* operator ->() const { return &self; }
+};
+class CResult_InitFeaturesDecodeErrorZ {
+private:
+	LDKCResult_InitFeaturesDecodeErrorZ self;
+public:
+	CResult_InitFeaturesDecodeErrorZ(const CResult_InitFeaturesDecodeErrorZ&) = delete;
+	CResult_InitFeaturesDecodeErrorZ(CResult_InitFeaturesDecodeErrorZ&& o) : self(o.self) { memset(&o, 0, sizeof(CResult_InitFeaturesDecodeErrorZ)); }
+	CResult_InitFeaturesDecodeErrorZ(LDKCResult_InitFeaturesDecodeErrorZ&& m_self) : self(m_self) { memset(&m_self, 0, sizeof(LDKCResult_InitFeaturesDecodeErrorZ)); }
+	operator LDKCResult_InitFeaturesDecodeErrorZ() && { LDKCResult_InitFeaturesDecodeErrorZ res = self; memset(&self, 0, sizeof(LDKCResult_InitFeaturesDecodeErrorZ)); return res; }
+	~CResult_InitFeaturesDecodeErrorZ() { CResult_InitFeaturesDecodeErrorZ_free(self); }
+	CResult_InitFeaturesDecodeErrorZ& operator=(CResult_InitFeaturesDecodeErrorZ&& o) { CResult_InitFeaturesDecodeErrorZ_free(self); self = o.self; memset(&o, 0, sizeof(CResult_InitFeaturesDecodeErrorZ)); return *this; }
+	LDKCResult_InitFeaturesDecodeErrorZ* operator &() { return &self; }
+	LDKCResult_InitFeaturesDecodeErrorZ* operator ->() { return &self; }
+	const LDKCResult_InitFeaturesDecodeErrorZ* operator &() const { return &self; }
+	const LDKCResult_InitFeaturesDecodeErrorZ* operator ->() const { return &self; }
 };
 class CResult_StaticPaymentOutputDescriptorDecodeErrorZ {
 private:
@@ -5841,21 +5840,6 @@ public:
 	const LDKCOption_CVec_NetAddressZZ* operator &() const { return &self; }
 	const LDKCOption_CVec_NetAddressZZ* operator ->() const { return &self; }
 };
-class C2Tuple_ProbabilisticScoringParametersNetworkGraphZ {
-private:
-	LDKC2Tuple_ProbabilisticScoringParametersNetworkGraphZ self;
-public:
-	C2Tuple_ProbabilisticScoringParametersNetworkGraphZ(const C2Tuple_ProbabilisticScoringParametersNetworkGraphZ&) = delete;
-	C2Tuple_ProbabilisticScoringParametersNetworkGraphZ(C2Tuple_ProbabilisticScoringParametersNetworkGraphZ&& o) : self(o.self) { memset(&o, 0, sizeof(C2Tuple_ProbabilisticScoringParametersNetworkGraphZ)); }
-	C2Tuple_ProbabilisticScoringParametersNetworkGraphZ(LDKC2Tuple_ProbabilisticScoringParametersNetworkGraphZ&& m_self) : self(m_self) { memset(&m_self, 0, sizeof(LDKC2Tuple_ProbabilisticScoringParametersNetworkGraphZ)); }
-	operator LDKC2Tuple_ProbabilisticScoringParametersNetworkGraphZ() && { LDKC2Tuple_ProbabilisticScoringParametersNetworkGraphZ res = self; memset(&self, 0, sizeof(LDKC2Tuple_ProbabilisticScoringParametersNetworkGraphZ)); return res; }
-	~C2Tuple_ProbabilisticScoringParametersNetworkGraphZ() { C2Tuple_ProbabilisticScoringParametersNetworkGraphZ_free(self); }
-	C2Tuple_ProbabilisticScoringParametersNetworkGraphZ& operator=(C2Tuple_ProbabilisticScoringParametersNetworkGraphZ&& o) { C2Tuple_ProbabilisticScoringParametersNetworkGraphZ_free(self); self = o.self; memset(&o, 0, sizeof(C2Tuple_ProbabilisticScoringParametersNetworkGraphZ)); return *this; }
-	LDKC2Tuple_ProbabilisticScoringParametersNetworkGraphZ* operator &() { return &self; }
-	LDKC2Tuple_ProbabilisticScoringParametersNetworkGraphZ* operator ->() { return &self; }
-	const LDKC2Tuple_ProbabilisticScoringParametersNetworkGraphZ* operator &() const { return &self; }
-	const LDKC2Tuple_ProbabilisticScoringParametersNetworkGraphZ* operator ->() const { return &self; }
-};
 class CResult__u832APIErrorZ {
 private:
 	LDKCResult__u832APIErrorZ self;
@@ -5901,21 +5885,6 @@ public:
 	const LDKCResult_DescriptionCreationErrorZ* operator &() const { return &self; }
 	const LDKCResult_DescriptionCreationErrorZ* operator ->() const { return &self; }
 };
-class CResult_PayeePubKeyErrorZ {
-private:
-	LDKCResult_PayeePubKeyErrorZ self;
-public:
-	CResult_PayeePubKeyErrorZ(const CResult_PayeePubKeyErrorZ&) = delete;
-	CResult_PayeePubKeyErrorZ(CResult_PayeePubKeyErrorZ&& o) : self(o.self) { memset(&o, 0, sizeof(CResult_PayeePubKeyErrorZ)); }
-	CResult_PayeePubKeyErrorZ(LDKCResult_PayeePubKeyErrorZ&& m_self) : self(m_self) { memset(&m_self, 0, sizeof(LDKCResult_PayeePubKeyErrorZ)); }
-	operator LDKCResult_PayeePubKeyErrorZ() && { LDKCResult_PayeePubKeyErrorZ res = self; memset(&self, 0, sizeof(LDKCResult_PayeePubKeyErrorZ)); return res; }
-	~CResult_PayeePubKeyErrorZ() { CResult_PayeePubKeyErrorZ_free(self); }
-	CResult_PayeePubKeyErrorZ& operator=(CResult_PayeePubKeyErrorZ&& o) { CResult_PayeePubKeyErrorZ_free(self); self = o.self; memset(&o, 0, sizeof(CResult_PayeePubKeyErrorZ)); return *this; }
-	LDKCResult_PayeePubKeyErrorZ* operator &() { return &self; }
-	LDKCResult_PayeePubKeyErrorZ* operator ->() { return &self; }
-	const LDKCResult_PayeePubKeyErrorZ* operator &() const { return &self; }
-	const LDKCResult_PayeePubKeyErrorZ* operator ->() const { return &self; }
-};
 class CResult_COption_MonitorEventZDecodeErrorZ {
 private:
 	LDKCResult_COption_MonitorEventZDecodeErrorZ self;
@@ -5930,6 +5899,21 @@ public:
 	LDKCResult_COption_MonitorEventZDecodeErrorZ* operator ->() { return &self; }
 	const LDKCResult_COption_MonitorEventZDecodeErrorZ* operator &() const { return &self; }
 	const LDKCResult_COption_MonitorEventZDecodeErrorZ* operator ->() const { return &self; }
+};
+class CResult_PayeePubKeyErrorZ {
+private:
+	LDKCResult_PayeePubKeyErrorZ self;
+public:
+	CResult_PayeePubKeyErrorZ(const CResult_PayeePubKeyErrorZ&) = delete;
+	CResult_PayeePubKeyErrorZ(CResult_PayeePubKeyErrorZ&& o) : self(o.self) { memset(&o, 0, sizeof(CResult_PayeePubKeyErrorZ)); }
+	CResult_PayeePubKeyErrorZ(LDKCResult_PayeePubKeyErrorZ&& m_self) : self(m_self) { memset(&m_self, 0, sizeof(LDKCResult_PayeePubKeyErrorZ)); }
+	operator LDKCResult_PayeePubKeyErrorZ() && { LDKCResult_PayeePubKeyErrorZ res = self; memset(&self, 0, sizeof(LDKCResult_PayeePubKeyErrorZ)); return res; }
+	~CResult_PayeePubKeyErrorZ() { CResult_PayeePubKeyErrorZ_free(self); }
+	CResult_PayeePubKeyErrorZ& operator=(CResult_PayeePubKeyErrorZ&& o) { CResult_PayeePubKeyErrorZ_free(self); self = o.self; memset(&o, 0, sizeof(CResult_PayeePubKeyErrorZ)); return *this; }
+	LDKCResult_PayeePubKeyErrorZ* operator &() { return &self; }
+	LDKCResult_PayeePubKeyErrorZ* operator ->() { return &self; }
+	const LDKCResult_PayeePubKeyErrorZ* operator &() const { return &self; }
+	const LDKCResult_PayeePubKeyErrorZ* operator ->() const { return &self; }
 };
 class CVec_C2Tuple_PublicKeyTypeZZ {
 private:
@@ -5961,6 +5945,21 @@ public:
 	const LDKCResult_RoutingFeesDecodeErrorZ* operator &() const { return &self; }
 	const LDKCResult_RoutingFeesDecodeErrorZ* operator ->() const { return &self; }
 };
+class CResult_QueryShortChannelIdsDecodeErrorZ {
+private:
+	LDKCResult_QueryShortChannelIdsDecodeErrorZ self;
+public:
+	CResult_QueryShortChannelIdsDecodeErrorZ(const CResult_QueryShortChannelIdsDecodeErrorZ&) = delete;
+	CResult_QueryShortChannelIdsDecodeErrorZ(CResult_QueryShortChannelIdsDecodeErrorZ&& o) : self(o.self) { memset(&o, 0, sizeof(CResult_QueryShortChannelIdsDecodeErrorZ)); }
+	CResult_QueryShortChannelIdsDecodeErrorZ(LDKCResult_QueryShortChannelIdsDecodeErrorZ&& m_self) : self(m_self) { memset(&m_self, 0, sizeof(LDKCResult_QueryShortChannelIdsDecodeErrorZ)); }
+	operator LDKCResult_QueryShortChannelIdsDecodeErrorZ() && { LDKCResult_QueryShortChannelIdsDecodeErrorZ res = self; memset(&self, 0, sizeof(LDKCResult_QueryShortChannelIdsDecodeErrorZ)); return res; }
+	~CResult_QueryShortChannelIdsDecodeErrorZ() { CResult_QueryShortChannelIdsDecodeErrorZ_free(self); }
+	CResult_QueryShortChannelIdsDecodeErrorZ& operator=(CResult_QueryShortChannelIdsDecodeErrorZ&& o) { CResult_QueryShortChannelIdsDecodeErrorZ_free(self); self = o.self; memset(&o, 0, sizeof(CResult_QueryShortChannelIdsDecodeErrorZ)); return *this; }
+	LDKCResult_QueryShortChannelIdsDecodeErrorZ* operator &() { return &self; }
+	LDKCResult_QueryShortChannelIdsDecodeErrorZ* operator ->() { return &self; }
+	const LDKCResult_QueryShortChannelIdsDecodeErrorZ* operator &() const { return &self; }
+	const LDKCResult_QueryShortChannelIdsDecodeErrorZ* operator ->() const { return &self; }
+};
 class CResult_InvoiceSemanticErrorZ {
 private:
 	LDKCResult_InvoiceSemanticErrorZ self;
@@ -5991,20 +5990,20 @@ public:
 	const LDKCResult_UpdateAddHTLCDecodeErrorZ* operator &() const { return &self; }
 	const LDKCResult_UpdateAddHTLCDecodeErrorZ* operator ->() const { return &self; }
 };
-class CResult_QueryShortChannelIdsDecodeErrorZ {
+class CVec_PhantomRouteHintsZ {
 private:
-	LDKCResult_QueryShortChannelIdsDecodeErrorZ self;
+	LDKCVec_PhantomRouteHintsZ self;
 public:
-	CResult_QueryShortChannelIdsDecodeErrorZ(const CResult_QueryShortChannelIdsDecodeErrorZ&) = delete;
-	CResult_QueryShortChannelIdsDecodeErrorZ(CResult_QueryShortChannelIdsDecodeErrorZ&& o) : self(o.self) { memset(&o, 0, sizeof(CResult_QueryShortChannelIdsDecodeErrorZ)); }
-	CResult_QueryShortChannelIdsDecodeErrorZ(LDKCResult_QueryShortChannelIdsDecodeErrorZ&& m_self) : self(m_self) { memset(&m_self, 0, sizeof(LDKCResult_QueryShortChannelIdsDecodeErrorZ)); }
-	operator LDKCResult_QueryShortChannelIdsDecodeErrorZ() && { LDKCResult_QueryShortChannelIdsDecodeErrorZ res = self; memset(&self, 0, sizeof(LDKCResult_QueryShortChannelIdsDecodeErrorZ)); return res; }
-	~CResult_QueryShortChannelIdsDecodeErrorZ() { CResult_QueryShortChannelIdsDecodeErrorZ_free(self); }
-	CResult_QueryShortChannelIdsDecodeErrorZ& operator=(CResult_QueryShortChannelIdsDecodeErrorZ&& o) { CResult_QueryShortChannelIdsDecodeErrorZ_free(self); self = o.self; memset(&o, 0, sizeof(CResult_QueryShortChannelIdsDecodeErrorZ)); return *this; }
-	LDKCResult_QueryShortChannelIdsDecodeErrorZ* operator &() { return &self; }
-	LDKCResult_QueryShortChannelIdsDecodeErrorZ* operator ->() { return &self; }
-	const LDKCResult_QueryShortChannelIdsDecodeErrorZ* operator &() const { return &self; }
-	const LDKCResult_QueryShortChannelIdsDecodeErrorZ* operator ->() const { return &self; }
+	CVec_PhantomRouteHintsZ(const CVec_PhantomRouteHintsZ&) = delete;
+	CVec_PhantomRouteHintsZ(CVec_PhantomRouteHintsZ&& o) : self(o.self) { memset(&o, 0, sizeof(CVec_PhantomRouteHintsZ)); }
+	CVec_PhantomRouteHintsZ(LDKCVec_PhantomRouteHintsZ&& m_self) : self(m_self) { memset(&m_self, 0, sizeof(LDKCVec_PhantomRouteHintsZ)); }
+	operator LDKCVec_PhantomRouteHintsZ() && { LDKCVec_PhantomRouteHintsZ res = self; memset(&self, 0, sizeof(LDKCVec_PhantomRouteHintsZ)); return res; }
+	~CVec_PhantomRouteHintsZ() { CVec_PhantomRouteHintsZ_free(self); }
+	CVec_PhantomRouteHintsZ& operator=(CVec_PhantomRouteHintsZ&& o) { CVec_PhantomRouteHintsZ_free(self); self = o.self; memset(&o, 0, sizeof(CVec_PhantomRouteHintsZ)); return *this; }
+	LDKCVec_PhantomRouteHintsZ* operator &() { return &self; }
+	LDKCVec_PhantomRouteHintsZ* operator ->() { return &self; }
+	const LDKCVec_PhantomRouteHintsZ* operator &() const { return &self; }
+	const LDKCVec_PhantomRouteHintsZ* operator ->() const { return &self; }
 };
 class CResult_CounterpartyChannelTransactionParametersDecodeErrorZ {
 private:
@@ -6095,21 +6094,6 @@ public:
 	LDKCVec_PublicKeyZ* operator ->() { return &self; }
 	const LDKCVec_PublicKeyZ* operator &() const { return &self; }
 	const LDKCVec_PublicKeyZ* operator ->() const { return &self; }
-};
-class CVec_PhantomRouteHintsZ {
-private:
-	LDKCVec_PhantomRouteHintsZ self;
-public:
-	CVec_PhantomRouteHintsZ(const CVec_PhantomRouteHintsZ&) = delete;
-	CVec_PhantomRouteHintsZ(CVec_PhantomRouteHintsZ&& o) : self(o.self) { memset(&o, 0, sizeof(CVec_PhantomRouteHintsZ)); }
-	CVec_PhantomRouteHintsZ(LDKCVec_PhantomRouteHintsZ&& m_self) : self(m_self) { memset(&m_self, 0, sizeof(LDKCVec_PhantomRouteHintsZ)); }
-	operator LDKCVec_PhantomRouteHintsZ() && { LDKCVec_PhantomRouteHintsZ res = self; memset(&self, 0, sizeof(LDKCVec_PhantomRouteHintsZ)); return res; }
-	~CVec_PhantomRouteHintsZ() { CVec_PhantomRouteHintsZ_free(self); }
-	CVec_PhantomRouteHintsZ& operator=(CVec_PhantomRouteHintsZ&& o) { CVec_PhantomRouteHintsZ_free(self); self = o.self; memset(&o, 0, sizeof(CVec_PhantomRouteHintsZ)); return *this; }
-	LDKCVec_PhantomRouteHintsZ* operator &() { return &self; }
-	LDKCVec_PhantomRouteHintsZ* operator ->() { return &self; }
-	const LDKCVec_PhantomRouteHintsZ* operator &() const { return &self; }
-	const LDKCVec_PhantomRouteHintsZ* operator ->() const { return &self; }
 };
 class COption_MonitorEventZ {
 private:

--- a/lightning-c-bindings/src/c_types/derived.rs
+++ b/lightning-c-bindings/src/c_types/derived.rs
@@ -3958,47 +3958,6 @@ impl Clone for CResult_ProbabilisticScoringParametersDecodeErrorZ {
 /// but with all dynamically-allocated buffers duplicated in new buffers.
 pub extern "C" fn CResult_ProbabilisticScoringParametersDecodeErrorZ_clone(orig: &CResult_ProbabilisticScoringParametersDecodeErrorZ) -> CResult_ProbabilisticScoringParametersDecodeErrorZ { Clone::clone(&orig) }
 #[repr(C)]
-/// A tuple of 2 elements. See the individual fields for the types contained.
-pub struct C2Tuple_ProbabilisticScoringParametersNetworkGraphZ {
-	/// The element at position 0
-	pub a: crate::lightning::routing::scoring::ProbabilisticScoringParameters,
-	/// The element at position 1
-	pub b: crate::lightning::routing::network_graph::NetworkGraph,
-}
-impl From<(crate::lightning::routing::scoring::ProbabilisticScoringParameters, crate::lightning::routing::network_graph::NetworkGraph)> for C2Tuple_ProbabilisticScoringParametersNetworkGraphZ {
-	fn from (tup: (crate::lightning::routing::scoring::ProbabilisticScoringParameters, crate::lightning::routing::network_graph::NetworkGraph)) -> Self {
-		Self {
-			a: tup.0,
-			b: tup.1,
-		}
-	}
-}
-impl C2Tuple_ProbabilisticScoringParametersNetworkGraphZ {
-	#[allow(unused)] pub(crate) fn to_rust(mut self) -> (crate::lightning::routing::scoring::ProbabilisticScoringParameters, crate::lightning::routing::network_graph::NetworkGraph) {
-		(self.a, self.b)
-	}
-}
-impl Clone for C2Tuple_ProbabilisticScoringParametersNetworkGraphZ {
-	fn clone(&self) -> Self {
-		Self {
-			a: Clone::clone(&self.a),
-			b: crate::lightning::routing::network_graph::NetworkGraph { inner: self.b.inner, is_owned: false},		}
-	}
-}
-#[no_mangle]
-/// Creates a new tuple which has the same data as `orig`
-/// but with all dynamically-allocated buffers duplicated in new buffers.
-pub extern "C" fn C2Tuple_ProbabilisticScoringParametersNetworkGraphZ_clone(orig: &C2Tuple_ProbabilisticScoringParametersNetworkGraphZ) -> C2Tuple_ProbabilisticScoringParametersNetworkGraphZ { Clone::clone(&orig) }
-/// Creates a new C2Tuple_ProbabilisticScoringParametersNetworkGraphZ from the contained elements.
-#[no_mangle]
-pub extern "C" fn C2Tuple_ProbabilisticScoringParametersNetworkGraphZ_new(a: crate::lightning::routing::scoring::ProbabilisticScoringParameters, b: &'static crate::lightning::routing::network_graph::NetworkGraph) -> C2Tuple_ProbabilisticScoringParametersNetworkGraphZ {
-	C2Tuple_ProbabilisticScoringParametersNetworkGraphZ { a, b: crate::lightning::routing::network_graph::NetworkGraph { inner: b.inner, is_owned: false}, }
-}
-
-#[no_mangle]
-/// Frees any resources used by the C2Tuple_ProbabilisticScoringParametersNetworkGraphZ.
-pub extern "C" fn C2Tuple_ProbabilisticScoringParametersNetworkGraphZ_free(_res: C2Tuple_ProbabilisticScoringParametersNetworkGraphZ) { }
-#[repr(C)]
 /// The contents of CResult_ProbabilisticScorerDecodeErrorZ
 pub union CResult_ProbabilisticScorerDecodeErrorZPtr {
 	/// A pointer to the contents in the success state.

--- a/lightning-c-bindings/src/lightning/routing/scoring.rs
+++ b/lightning-c-bindings/src/lightning/routing/scoring.rs
@@ -1007,9 +1007,10 @@ pub(crate) extern "C" fn ProbabilisticScorer_write_void(obj: *const c_void) -> c
 }
 #[no_mangle]
 /// Read a ProbabilisticScorer from a byte array, created by ProbabilisticScorer_write
-pub extern "C" fn ProbabilisticScorer_read(ser: crate::c_types::u8slice, arg: crate::c_types::derived::C2Tuple_ProbabilisticScoringParametersNetworkGraphZ) -> crate::c_types::derived::CResult_ProbabilisticScorerDecodeErrorZ {
-	let (mut orig_arg_0, mut orig_arg_1) = arg.to_rust(); let mut local_arg = (*unsafe { Box::from_raw(orig_arg_0.take_inner()) }, orig_arg_1.get_native_ref());
-	let arg_conv = local_arg;
+pub extern "C" fn ProbabilisticScorer_read(ser: crate::c_types::u8slice, arg_a: crate::lightning::routing::scoring::ProbabilisticScoringParameters, arg_b: &crate::lightning::routing::network_graph::NetworkGraph) -> crate::c_types::derived::CResult_ProbabilisticScorerDecodeErrorZ {
+	let arg_a_conv = *unsafe { Box::from_raw(arg_a.take_inner()) };
+	let arg_b_conv = arg_b.get_native_ref();
+	let arg_conv = (arg_a_conv, arg_b_conv);
 	let res: Result<lightning::routing::scoring::ProbabilisticScorer<&lightning::routing::network_graph::NetworkGraph>, lightning::ln::msgs::DecodeError> = crate::c_types::deserialize_obj_arg(ser, arg_conv);
 	let mut local_res = match res { Ok(mut o) => crate::c_types::CResultTempl::ok( { crate::lightning::routing::scoring::ProbabilisticScorer { inner: ObjOps::heap_alloc(o), is_owned: true } }).into(), Err(mut e) => crate::c_types::CResultTempl::err( { crate::lightning::ln::msgs::DecodeError { inner: ObjOps::heap_alloc(e), is_owned: true } }).into() };
 	local_res


### PR DESCRIPTION
I'm not really a big fan of the implicit clone in enum handling here, but short of making the enums opaque or having a reference flag like we do in opaques, I'm not sure what else to do.

Fixes #65.