### PR TITLE
Make `Str`'s `clone` always clone the underlying bytes

### DIFF
--- a/lightning-c-bindings/src/c_types/mod.rs
+++ b/lightning-c-bindings/src/c_types/mod.rs
@@ -569,7 +569,7 @@ impl Into<Str> for String {
 }
 impl Clone for Str {
 	fn clone(&self) -> Self {
-		self.into_str().clone().into()
+		String::from(self.into_str()).into()
 	}
 }
 


### PR DESCRIPTION
Its incredibly unexpected that you can clone a higher-level object
(eg an Event with a ClosureReason that contains an `Str`) and have
a pointer back to the original object. To avoid this, `clone` needs
to actually `clone`.