### PR TITLE
[ldk-net] Correct pollfds array offset after reads

### DIFF
--- a/ldk-net/ldk_net.c
+++ b/ldk-net/ldk_net.c
@@ -266,8 +266,8 @@ static void *sock_thread_fn(void* arg) {
 								if (*res.contents.result) {
 									lockres = pthread_mutex_lock(&handler->sockets_mutex);
 									assert(lockres == 0);
-									assert(handler->pollfds[i - 1].fd == pollfds[i].fd); // Only we change fd order!
-									handler->pollfds[i - 1].events = POLLOUT;
+									assert(handler->pollfds[i].fd == pollfds[i].fd); // Only we change fd order!
+									handler->pollfds[i].events = POLLOUT;
 									lockres = pthread_mutex_unlock(&handler->sockets_mutex);
 									assert(lockres == 0);
 								}


### PR DESCRIPTION
Previously, we were copying the pollfds array at an offset of one
into the handler thread's stack. However, when it was changed to
copying at a 0 offset (adding the pipe read fd at the end instead
of beginning), the disable-read handling code was not updated.

This leads to an assertion failure at runtime if LDK decides we
need to stop reading due to the outbound buffer of a peer being
full.