### PR TITLE
Update `deterministic-build-wrappers` to include a rapid-gossip-sync match

### DIFF
--- a/deterministic-build-wrappers/rustc
+++ b/deterministic-build-wrappers/rustc
@@ -10,7 +10,7 @@ IS_LIGHTNING=false
 for ((i=0; i<"${#args[@]}"; ++i)); do
     case ${args[i]} in
         --crate-name)
-			if [ "${args[i+1]}" = "lightning" -o "${args[i+1]}" = "lightning_background_processor" -o "${args[i+1]}" = "lightning_invoice" -o "${args[i+1]}" = "lightning_persister" -o "${args[i+1]}" = "ldk" ]; then
+			if [ "${args[i+1]}" = "lightning" -o "${args[i+1]}" = "lightning_background_processor" -o "${args[i+1]}" = "lightning_invoice" -o "${args[i+1]}" = "lightning_persister" -o "${args[i+1]}" = "lightning_rapid_gossip_sync" -o "${args[i+1]}" = "ldk" ]; then
 				IS_LIGHTNING=true
 			fi
 			;;


### PR DESCRIPTION
This should fix build determinism for java.