### PR TITLE
[0.0.115] Fix strict-aliasing violation on traits holding inner fields

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,11 @@ jobs:
           git checkout 0.0.115-bindings
       - name: Fix Github Actions to not be broken
         run: git config --global --add safe.directory /__w/ldk-c-bindings/ldk-c-bindings
+      - name: Pin proc-macro and quote to meet MSRV
+        run: |
+          cd c-bindings-gen
+          cargo update -p quote --precise "1.0.30" --verbose
+          cargo update -p proc-macro2 --precise "1.0.65" --verbose
       - name: Rebuild bindings without std, and check the sample app builds + links
         run: ./genbindings.sh ./rust-lightning false
       - name: Rebuild bindings, and check the sample app builds + links

--- a/genbindings.sh
+++ b/genbindings.sh
@@ -231,12 +231,18 @@ cbindgen -v --config cbindgen.toml -o include/lightning.h >/dev/null 2>&1
 if is_gnu_sed; then
 	sed -i 's/typedef LDKnative.*Import.*LDKnative.*;//g' include/lightning.h
 
+	# UnsafeCell is `repr(transparent)` so should be ignored here
+	sed -i 's/LDKUnsafeCell<\(.*\)> /\1 /g' include/lightning.h
+
 	# stdlib.h doesn't exist in clang's wasm sysroot, and cbindgen
 	# doesn't actually use it anyway, so drop the import.
 	sed -i 's/#include <stdlib.h>/#include "ldk_rust_types.h"/g' include/lightning.h
 else
 	# OSX sed is for some reason not compatible with GNU sed
 	sed -i '' 's/typedef LDKnative.*Import.*LDKnative.*;//g' include/lightning.h
+
+	# UnsafeCell is `repr(transparent)` so should be ignored by cbindgen
+	sed -i '' 's/LDKUnsafeCell<\(.*\)> /\1 /g' include/lightning.h
 
 	# stdlib.h doesn't exist in clang's wasm sysroot, and cbindgen
 	# doesn't actually use it anyway, so drop the import.

--- a/lightning-c-bindings/include/lightning.h
+++ b/lightning-c-bindings/include/lightning.h
@@ -7884,7 +7884,7 @@ typedef struct LDKChannelSigner {
    /**
     * Returns the holder's channel public keys and basepoints.
     */
-   struct LDKChannelPublicKeys pubkeys;
+   LDKChannelPublicKeys pubkeys;
    /**
     * Fill in the pubkeys field as a reference to it will be given to Rust after this returns
     * Note that this takes a pointer to this object, not the this_ptr like other methods do


### PR DESCRIPTION
When we map a trait method which returns a reference to a struct,
we map it by storing said struct in the trait implementation
struct. Then, we create a setter method which ensures the new field
is set. Sadly, because the original Rust trait method may take a
non-mutable reference to self, we have to update the field without
a mutable reference to the trait implementation struct.

Previously we did this by simply unsafe-casting a pointer to
mutable, which violates the aliasing rules in Rust. In a recent
rustc (at least on macOS), this broke.

Here, we convert the stored struct to wrap it in an `UnsafeCell`,
which fixes the issue.