### PR TITLE
Fix race in peer connection in C++ demo app

### DIFF
--- a/deterministic-build-wrappers/clang-x86_64-windows
+++ b/deterministic-build-wrappers/clang-x86_64-windows
@@ -1,0 +1,2 @@
+#!/bin/bash
+clang -target x86_64-pc-windows-gnu -L/usr/lib/gcc/x86_64-w64-mingw32/12-win32/ "$@"

--- a/lightning-c-bindings/demo.cpp
+++ b/lightning-c-bindings/demo.cpp
@@ -242,6 +242,7 @@ public:
 
 		// Then disconnect the "main" connection, while another connection is being made.
 		PeerManager_disconnect_by_node_id(&net1, ChannelManager_get_our_node_id(&cm2));
+		PeerManager_disconnect_by_node_id(&net2, ChannelManager_get_our_node_id(&cm1));
 		assert(!socket_connect(node1_handler, ChannelManager_get_our_node_id(&cm2), (sockaddr*)&listen_addr, sizeof(listen_addr)));
 
 		std::cout << __FILE__ << ":" << __LINE__ << " - " << "Awaiting new connection handshake..." << std::endl;


### PR DESCRIPTION
When we disconnect then immediately reconnect from one peer we may still get the second connection through before the disconnection is handled on the other end, causing connection failures. We fix this here by disconnecting on both ends before reconnecting.