### PR TITLE
Update CI/Cargo.toml references to 0.0.122

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           git clone https://github.com/rust-bitcoin/rust-lightning
           cd rust-lightning
-          git checkout 0.0.121-bindings
+          git checkout 0.0.122-bindings
       - name: Fix Github Actions to not be broken
         run: git config --global --add safe.directory /__w/ldk-c-bindings/ldk-c-bindings
       - name: Pin proc-macro and quote to meet MSRV
@@ -106,7 +106,7 @@ jobs:
         run: |
           git clone https://github.com/rust-bitcoin/rust-lightning
           cd rust-lightning
-          git checkout 0.0.121-bindings
+          git checkout 0.0.122-bindings
       - name: Fix Github Actions to not be broken
         run: git config --global --add safe.directory /__w/ldk-c-bindings/ldk-c-bindings
       - name: Fetch MacOS SDK
@@ -153,7 +153,7 @@ jobs:
         run: |
           git clone https://github.com/rust-bitcoin/rust-lightning
           cd rust-lightning
-          git checkout 0.0.121-bindings
+          git checkout 0.0.122-bindings
       - name: Rebuild bindings using Apple clang, and check the sample app builds + links
         run: ./genbindings.sh ./rust-lightning true
       - name: Rebuild bindings using upstream clang, and check the sample app builds + links

--- a/lightning-c-bindings/Cargo.toml
+++ b/lightning-c-bindings/Cargo.toml
@@ -22,11 +22,11 @@ std = ["bitcoin/std", "lightning/std", "lightning-invoice/std", "lightning-backg
 bitcoin = { version = "0.30", default-features = false }
 secp256k1 = { version = "0.27", features = ["global-context", "recovery"] }
 # Note that the following line is matched by genbindings to update the path
-lightning = { git = "https://github.com/lightningdevkit/rust-lightning", branch = "0.0.121-bindings", default-features = false }
-lightning-persister = { git = "https://github.com/lightningdevkit/rust-lightning", branch = "0.0.121-bindings", default-features = false }
-lightning-invoice = { git = "https://github.com/lightningdevkit/rust-lightning", branch = "0.0.121-bindings", default-features = false }
-lightning-background-processor = { git = "https://github.com/lightningdevkit/rust-lightning", branch = "0.0.121-bindings", default-features = false }
-lightning-rapid-gossip-sync = { git = "https://github.com/lightningdevkit/rust-lightning", branch = "0.0.121-bindings", default-features = false }
+lightning = { git = "https://github.com/lightningdevkit/rust-lightning", branch = "0.0.122-bindings", default-features = false }
+lightning-persister = { git = "https://github.com/lightningdevkit/rust-lightning", branch = "0.0.122-bindings", default-features = false }
+lightning-invoice = { git = "https://github.com/lightningdevkit/rust-lightning", branch = "0.0.122-bindings", default-features = false }
+lightning-background-processor = { git = "https://github.com/lightningdevkit/rust-lightning", branch = "0.0.122-bindings", default-features = false }
+lightning-rapid-gossip-sync = { git = "https://github.com/lightningdevkit/rust-lightning", branch = "0.0.122-bindings", default-features = false }
 
 core2 = { version = "0.3.0", optional = true, default-features = false }
 


### PR DESCRIPTION
There's not really anything required for 0.0.122 cause the public API didn't really change. Depends on https://github.com/lightningdevkit/rust-lightning/pull/3013